### PR TITLE
feat: add sleep_idle_delay scaling target

### DIFF
--- a/koyeb/resource_koyeb_service.go
+++ b/koyeb/resource_koyeb_service.go
@@ -600,6 +600,13 @@ func autoScalingTargetSchema() *schema.Resource {
 				Elem:        autoScalingTargetValueSchema(),
 				Set:         schema.HashResource(autoScalingTargetValueSchema()),
 			},
+			"sleep_idle_delay": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: "The delay in seconds after which a service that received no requests is scaled to zero",
+				Elem:        autoScalingTargetValueSchema(),
+				Set:         schema.HashResource(autoScalingTargetValueSchema()),
+			},
 		},
 	}
 }
@@ -879,6 +886,18 @@ func expandScalings(config []interface{}) []koyeb.DeploymentScaling {
 				}
 			}
 
+			if target["sleep_idle_delay"] != nil {
+				sleepIdleDelay := target["sleep_idle_delay"].(*schema.Set).List()
+				for _, rawSleepIdleDelay := range sleepIdleDelay {
+					sleepIdleDelay := rawSleepIdleDelay.(map[string]interface{})
+					s.Targets = append(s.Targets, koyeb.DeploymentScalingTarget{
+						SleepIdleDelay: &koyeb.DeploymentScalingTargetSleepIdleDelay{
+							Value: toOpt(int64(sleepIdleDelay["value"].(int))),
+						},
+					})
+				}
+			}
+
 		}
 
 		scalings = append(scalings, s)
@@ -946,6 +965,16 @@ func flattenScalings(scalings *[]koyeb.DeploymentScaling) []map[string]interface
 					[]interface{}{
 						map[string]interface{}{
 							"value": int(reqRespTime.GetValue()),
+						},
+					},
+				)
+			}
+			if sleepIdleDelay, ok := target.GetSleepIdleDelayOk(); ok {
+				targetMap["sleep_idle_delay"] = schema.NewSet(
+					schema.HashResource(autoScalingTargetValueSchema()),
+					[]interface{}{
+						map[string]interface{}{
+							"value": int(sleepIdleDelay.GetValue()),
 						},
 					},
 				)

--- a/koyeb/resource_koyeb_service.go
+++ b/koyeb/resource_koyeb_service.go
@@ -603,7 +603,7 @@ func autoScalingTargetSchema() *schema.Resource {
 			"sleep_idle_delay": {
 				Type:        schema.TypeSet,
 				Optional:    true,
-				Description: "The delay in seconds after which a service that received no requests is scaled to zero",
+				Description: "The delay in seconds after which a service that has received no requests is scaled to zero. Required when min is set to 0 (scale-to-zero).",
 				Elem:        autoScalingTargetValueSchema(),
 				Set:         schema.HashResource(autoScalingTargetValueSchema()),
 			},


### PR DESCRIPTION
## Summary

- Adds `sleep_idle_delay` to the scaling target schema, expand (Terraform→API), and flatten (API→Terraform) logic
- The Koyeb API now requires this target when `min_scaling` is 0 (scale-to-zero), otherwise deploys fail with: `scale to zero autoscaling target is required if min_scaling is 0`
- The `DeploymentScalingTargetSleepIdleDelay` type already exists in the pinned `koyeb-api-client-go` — only the Terraform provider mapping was missing
- Follows the same pattern as the existing 5 scaling targets

## Usage

```hcl
scalings {
  min = 0
  max = 4
  targets {
    average_mem {
      value = 80
    }
    sleep_idle_delay {
      value = 300
    }
  }
}
```

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./... -short` passes
- [x] `go vet ./...` passes